### PR TITLE
hard Code In Default InitialState

### DIFF
--- a/src/templates/menu.js
+++ b/src/templates/menu.js
@@ -140,10 +140,7 @@ const MenuPage = ({ pageContext, location }) => {
             </div>
           </div>
           <Tabs
-            selectedTab={
-              queryString.parse(location.search).tab ||
-              pageContext.selectedMenuTab
-            }
+            selectedTab={queryString.parse(location.search).tab || 'To Share?'}
             TabArray={data.allMenuJson.edges.map(edgeToTab(pageContext))}
           />
         </Layout>


### PR DESCRIPTION
i think this will fix the issue, however please double check.

I think this is a timing issue that the queryString isn't avaliable until running on the client, whereas the default state is obviously always available on build.

just remembered you said it was already working locally @lukebennett88 so its posible i'm seeing the same thing and this fix is doing actual nothing.